### PR TITLE
Fixed Trello: "Take out "Inject This View" from inspector". 

### DIFF
--- a/Editor/uFrameEditors/ViewInspector.cs
+++ b/Editor/uFrameEditors/ViewInspector.cs
@@ -315,10 +315,10 @@ public class ViewInspector : uFrameInspector
             "Should this field be saved and loaded when saving a scene's in-game state. e.g. GameManager.ActiveSceneManager.Load(...); GameManger.ActiveSceneManager.Save(...);");
         EditorGUILayout.PropertyField(saveProperty, new GUIContent("Save & Load"));
 
-        var injectProperty = serializedObject.FindProperty("_InjectView");
-        Info(
-            "Should this view be injected with Dependencies defined in the GameContainer.  e.g.GameManager.Resolve<MyViewModel>(ResolveName);");
-        EditorGUILayout.PropertyField(injectProperty, new GUIContent("Inject This View"));
+//        var injectProperty = serializedObject.FindProperty("_InjectView");
+//        Info(
+//            "Should this view be injected with Dependencies defined in the GameContainer.  e.g.GameManager.Resolve<MyViewModel>(ResolveName);");
+//        EditorGUILayout.PropertyField(injectProperty, new GUIContent("Inject This View"));
 
         //var useHashCode = serializedObject.FindProperty("_UseHashcodeAsIdentifier");
         //Info(


### PR DESCRIPTION
...ked as fixed for 1.5.1 but never was.  If the option does nothing, why leave it in and confuse everyone?