### PR TITLE
Reduced awkward casts when working with commands with arguments

### DIFF
--- a/Base/Commands/CommandWith.cs
+++ b/Base/Commands/CommandWith.cs
@@ -268,3 +268,31 @@ public class CommandWithSenderAndArgument<TSender,TArgument> : CommandBase<TArgu
         return true;
     }
 }
+
+public static partial class ObservableExtensions
+{
+    public static IDisposable Subscribe<T>(this CommandBase<T> source)
+    {
+        return source.Subscribe(Observer.Create<T>(Stubs.Ignore<T>, Stubs.Throw, Stubs.Nop));
+    }
+
+    public static IDisposable Subscribe<T>(this CommandBase<T> source, Action<T> onNext)
+    {
+        return source.Subscribe(Observer.Create(onNext, Stubs.Throw, Stubs.Nop));
+    }
+
+    public static IDisposable Subscribe<T>(this CommandBase<T> source, Action<T> onNext, Action<Exception> onError)
+    {
+        return source.Subscribe(Observer.Create(onNext, onError, Stubs.Nop));
+    }
+
+    public static IDisposable Subscribe<T>(this CommandBase<T> source, Action<T> onNext, Action onCompleted)
+    {
+        return source.Subscribe(Observer.Create(onNext, Stubs.Throw, onCompleted));
+    }
+
+    public static IDisposable Subscribe<T>(this CommandBase<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted)
+    {
+        return source.Subscribe(Observer.Create(onNext, onError, onCompleted));
+    }
+}

--- a/Base/Commands/UFCommand.cs
+++ b/Base/Commands/UFCommand.cs
@@ -42,25 +42,48 @@ public abstract class UFCommand<T> : ICommandWith<T>
     public event CommandEvent OnCommandExecuting;
 
     public object Sender { get; set; }
-    public object Parameter { get; set; }
+
+    public T Parameter { get; set; }
+
+    object IParameterCommand.Parameter
+    {
+        get
+        {
+            return Parameter;
+        }
+        set
+        {
+            Parameter = (T)value;
+        }
+    }
 
     protected abstract void Perform(T arg);
 
     public void Execute()
     {
         OnOnCommandExecuting();
-        Execute((T)Parameter);
+        Execute(Parameter);
         OnOnCommandComplete();
     }
 
-    public void Execute(object arg)
+    public void Execute(T arg)
     {
         Parameter = arg;
         Execute();
     }
 
-    public virtual bool CanExecute(object parameter)
+    void ICommand.Execute(object arg)
+    {
+        Execute((T) arg);
+    }
+
+    public virtual bool CanExecute(T parameter)
     {
         return true;
+    }
+
+    bool ICommand.CanExecute(object parameter)
+    {
+        return CanExecute((T)parameter);
     }
 }

--- a/Base/Commands/YieldCommandWith.cs
+++ b/Base/Commands/YieldCommandWith.cs
@@ -92,6 +92,28 @@ public class YieldCommandWith<T> : ICommandWith<T>
 
         return Disposable.Create(() => OnCommandExecuted -= handler);
     }
+
+    T ICommandWith<T>.Parameter
+    {
+        get
+        {
+            return (T)((IParameterCommand)this).Parameter;
+        }
+        set
+        {
+            ((IParameterCommand)this).Parameter = value;
+        }
+    }
+
+    public void Execute(T parameter)
+    {
+        ((ICommand) this).Execute(parameter);
+    }
+
+    public bool CanExecute(T parameter)
+    {
+        return ((ICommand) this).CanExecute(parameter);
+    }
 }
 /// <summary>
 /// A coroutine command with a parameter.
@@ -118,6 +140,28 @@ public class YieldCommandWithSender<T> : ICommandWith<T>
     public object Sender { get; set; }
 
     public object Parameter { get; set; }
+
+    T ICommandWith<T>.Parameter
+    {
+        get
+        {
+            return (T)((IParameterCommand)this).Parameter;
+        }
+        set
+        {
+            ((IParameterCommand)this).Parameter = value;
+        }
+    }
+
+    public void Execute(T parameter)
+    {
+        ((ICommand) this).Execute(parameter);
+    }
+
+    public bool CanExecute(T parameter)
+    {
+        return ((ICommand) this).CanExecute(parameter);
+    }
 
     protected Func<T, IEnumerator> EnumeratorDelegate
     {
@@ -215,6 +259,28 @@ public class YieldCommandWithSenderAndArgument<TSender, TArgument> : ICommandWit
     public object Sender { get; set; }
 
     public object Parameter { get; set; }
+
+    TArgument ICommandWith<TArgument>.Parameter
+    {
+        get
+        {
+            return (TArgument)((IParameterCommand)this).Parameter;
+        }
+        set
+        {
+            ((IParameterCommand)this).Parameter = value;
+        }
+    }
+
+    public void Execute(TArgument parameter)
+    {
+        ((ICommand) this).Execute(parameter);
+    }
+
+    public bool CanExecute(TArgument parameter)
+    {
+        return ((ICommand) this).CanExecute(parameter);
+    }
 
     protected Func<TSender, TArgument, IEnumerator> EnumeratorDelegate
     {

--- a/Shared/ICommand.cs
+++ b/Shared/ICommand.cs
@@ -39,6 +39,11 @@ public interface IParameterCommand : ICommand
 public interface ICommandWith<T> : IParameterCommand
 {
     //IEnumerator Execute(T parameter);
+
+    new T Parameter { get; set; }
+
+    void Execute(T parameter);
+    bool CanExecute(T parameter);
 }
 #if DLL
 }

--- a/Shared/ModelPropertyBase.cs
+++ b/Shared/ModelPropertyBase.cs
@@ -93,7 +93,7 @@ public class P<T> : ISubject<T>, IObservableProperty, INotifyPropertyChanged
             }));
         }
 
-        OnNext(action());
+        //OnNext(action());
 
         return Disposable.Create(() =>
         {


### PR DESCRIPTION
This enforces strong typing when working with commands with an argument. Also adds ability to subscribe to command with an argument, while receiving the argument in the callback.

Before:
```csharp
public override void PickUpBoosterExecuted() {
    BoosterViewModel booster = (BoosterViewModel) Piano.PickUpBooster.Parameter;
    ...
}

public override void Bind() {
    base.Bind();
    // PickUpBooster command has an argument of type Booster
    Piano.BoosterReceiver.PickUpBooster
        .Subscribe(unit => {
            // parameter is of type Unit, but should be BoosterViewModel
        });
}
```
After:
```csharp
public override void PickUpBoosterExecuted() {
    BoosterViewModel booster = Piano.PickUpBooster.Parameter;
    ...
}

public override void Bind() {
    base.Bind();
    Piano.BoosterReceiver.PickUpBooster
        .Subscribe(boosterViewModel => {
            // parameter is of type BoosterViewModel
        });
}
```