### PR TITLE
Fixed usage of null coalescing operator when operands are UnityEngine.Object

### DIFF
--- a/Base/Bindings/ModelViewModelCollectionBinding.cs
+++ b/Base/Bindings/ModelViewModelCollectionBinding.cs
@@ -235,7 +235,7 @@ public class ModelViewModelCollectionBinding : Binding
         }
         else
         {
-            var targetTransform = Parent ?? SourceView.transform;
+            var targetTransform = Parent != null ? Parent : SourceView.transform;
             if (targetTransform != null)
             {
                 for (var i = 0; i < targetTransform.childCount; i++)
@@ -277,7 +277,7 @@ public class ModelViewModelCollectionBinding : Binding
             GameObjectLookup.Clear();
             return;
         }
-        var targetTransform = Parent ?? SourceView.transform;
+        var targetTransform = Parent != null ? Parent : SourceView.transform;
         if (changeArgs.NewItems != null)
             foreach (var item in changeArgs.NewItems)
             {

--- a/Base/Bindings/ModelViewPropertyBinding.cs
+++ b/Base/Bindings/ModelViewPropertyBinding.cs
@@ -55,7 +55,7 @@ public class ModelViewPropertyBinding : Binding,IDisposable
 
 
             // Parent it defaulting to the view
-            view.transform.parent = Parent ?? view.transform;
+            view.transform.parent = Parent != null ? Parent : view.transform;
         }
     }
 

--- a/Base/GameManager.cs
+++ b/Base/GameManager.cs
@@ -100,7 +100,17 @@ public class GameManager : MonoBehaviour, ICommandDispatcher
     /// </summary>
     public static SceneManager ActiveSceneManager
     {
-        get { return _activeSceneManager ?? (_activeSceneManager = Instance._Start) ?? (_activeSceneManager = UnityEngine.Object.FindObjectOfType<SceneManager>()); }
+        get {
+            if (_activeSceneManager != null)
+                return _activeSceneManager;
+
+            _activeSceneManager = Instance._Start;
+            if (_activeSceneManager != null)
+                return _activeSceneManager;
+
+            _activeSceneManager = UnityEngine.Object.FindObjectOfType<SceneManager>();
+            return _activeSceneManager;
+        }
         private set { _activeSceneManager = value; }
     }
 

--- a/Base/Views/ViewComponent.cs
+++ b/Base/Views/ViewComponent.cs
@@ -8,7 +8,7 @@ public abstract class ViewComponent : MonoBehaviour, IBindingProvider
 
     public ViewBase View
     {
-        get { return _view ?? (this.GetView()); }
+        get { return _view != null ? _view : this.GetView(); }
         set { _view = value; }
     }
 


### PR DESCRIPTION
It's better to avoid using null coalescing operator when operands are descendants of UnityEngine.Object. The reason is: null coalescing operator basically calls Object.ReferenceEquals(...), which only compares the references themselves, ignoring the operator overloads. UnityEngine.Object implements overload for != and == operators, as it is nothing more that a wrapper for C++ object, and it _is_ possible for a C# object to have no corresponding C++ object attached to it. This is what happened here. Little known fact, but serialized properties of Unity API types _always_ have a C# object attached, even when they look empty from the Inspector. Why? This is made to spit out error messages like ```"UnassignedReferenceException - The variable SomeTransform of 'Transform' has not been assigned. You probably need to assign the SomeTransform variable of the Transform script in the inspector"```. And Unity is not doing this does in the builds. So bam, we have a "real" null in the build, but in the Editor we have an actual object disguised as null.


TL;DR: this was leading to a different behaviour between playing from the Unity Editor, a playing from a build. This took *quite* some time to figure out...